### PR TITLE
feat: Display three interactive kaleidoscopes

### DIFF
--- a/src/components/Kaleidoscope.astro
+++ b/src/components/Kaleidoscope.astro
@@ -1,24 +1,31 @@
-<div class="relative w-full h-screen overflow-hidden">
-  <canvas id="kaleidoscope" class="absolute inset-0 w-full h-full"></canvas>
+---
+export interface Props {
+  id: string;
+}
+const { id } = Astro.props;
+---
+
+<div class="relative w-full h-[33vh] overflow-hidden">
+  <canvas id={`kaleidoscope-${id}`} class="absolute inset-0 w-full h-full"></canvas>
   
   <!-- Interactive Controls -->
   <div class="absolute bottom-4 left-4 bg-black/50 p-4 rounded-lg backdrop-blur-sm">
     <div class="space-y-4">
       <div>
-        <label class="block text-sm mb-1">Segments: <span id="segmentsValue">12</span></label>
-        <input type="range" id="segments" min="4" max="24" value="12" class="w-full" />
+        <label class="block text-sm mb-1">Segments: <span id={`segmentsValue-${id}`}>12</span></label>
+        <input type="range" id={`segments-${id}`} min="4" max="24" value="12" class="w-full" />
       </div>
       <div>
-        <label class="block text-sm mb-1">Rotation Speed: <span id="speedValue">0.005</span></label>
-        <input type="range" id="speed" min="0" max="0.02" step="0.001" value="0.005" class="w-full" />
+        <label class="block text-sm mb-1">Rotation Speed: <span id={`speedValue-${id}`}>0.005</span></label>
+        <input type="range" id={`speed-${id}`} min="0" max="0.02" step="0.001" value="0.005" class="w-full" />
       </div>
       <div>
-        <label class="block text-sm mb-1">Pattern Size: <span id="sizeValue">200</span></label>
-        <input type="range" id="size" min="50" max="400" value="200" class="w-full" />
+        <label class="block text-sm mb-1">Pattern Size: <span id={`sizeValue-${id}`}>200</span></label>
+        <input type="range" id={`size-${id}`} min="50" max="400" value="200" class="w-full" />
       </div>
       <div>
         <label class="block text-sm mb-1">Pattern Style</label>
-        <select id="patternStyle" class="w-full bg-black/50 rounded p-1">
+        <select id={`patternStyle-${id}`} class="w-full bg-black/50 rounded p-1">
           <option value="triangle">Triangle</option>
           <option value="circle">Circle</option>
           <option value="star">Star</option>
@@ -28,7 +35,7 @@
   </div>
 </div>
 
-<script>
+<script define:vars={{ id }}>
   class Kaleidoscope {
     private canvas: HTMLCanvasElement;
     private ctx: CanvasRenderingContext2D;
@@ -42,9 +49,11 @@
     private isMouseDown: boolean = false;
     private lastMouseX: number = 0;
     private lastMouseY: number = 0;
+    private id: string;
 
-    constructor() {
-      this.canvas = document.getElementById('kaleidoscope') as HTMLCanvasElement;
+    constructor(id: string) {
+      this.id = id;
+      this.canvas = document.getElementById(`kaleidoscope-${this.id}`) as HTMLCanvasElement;
       this.ctx = this.canvas.getContext('2d')!;
       this.init();
       this.setupControls();
@@ -57,24 +66,24 @@
     }
 
     private setupControls() {
-      const segmentsInput = document.getElementById('segments') as HTMLInputElement;
-      const speedInput = document.getElementById('speed') as HTMLInputElement;
-      const sizeInput = document.getElementById('size') as HTMLInputElement;
-      const patternSelect = document.getElementById('patternStyle') as HTMLSelectElement;
+      const segmentsInput = document.getElementById(`segments-${this.id}`) as HTMLInputElement;
+      const speedInput = document.getElementById(`speed-${this.id}`) as HTMLInputElement;
+      const sizeInput = document.getElementById(`size-${this.id}`) as HTMLInputElement;
+      const patternSelect = document.getElementById(`patternStyle-${this.id}`) as HTMLSelectElement;
 
       segmentsInput.addEventListener('input', (e) => {
         this.segments = parseInt((e.target as HTMLInputElement).value);
-        document.getElementById('segmentsValue')!.textContent = this.segments.toString();
+        document.getElementById(`segmentsValue-${this.id}`)!.textContent = this.segments.toString();
       });
 
       speedInput.addEventListener('input', (e) => {
         this.rotationSpeed = parseFloat((e.target as HTMLInputElement).value);
-        document.getElementById('speedValue')!.textContent = this.rotationSpeed.toFixed(3);
+        document.getElementById(`speedValue-${this.id}`)!.textContent = this.rotationSpeed.toFixed(3);
       });
 
       sizeInput.addEventListener('input', (e) => {
         this.patternSize = parseInt((e.target as HTMLInputElement).value);
-        document.getElementById('sizeValue')!.textContent = this.patternSize.toString();
+        document.getElementById(`sizeValue-${this.id}`)!.textContent = this.patternSize.toString();
       });
 
       patternSelect.addEventListener('change', (e) => {
@@ -83,8 +92,8 @@
     }
 
     private resize() {
-      this.canvas.width = window.innerWidth;
-      this.canvas.height = window.innerHeight;
+      this.canvas.width = this.canvas.clientWidth;
+      this.canvas.height = this.canvas.clientHeight;
     }
 
     private setupEventListeners() {
@@ -99,8 +108,8 @@
           const dy = this.mouseY - this.lastMouseY;
           this.rotation += dx * 0.01;
           this.patternSize = Math.max(50, Math.min(400, this.patternSize - dy));
-          document.getElementById('size')!.value = this.patternSize.toString();
-          document.getElementById('sizeValue')!.textContent = this.patternSize.toString();
+          document.getElementById(`size-${this.id}`)!.value = this.patternSize.toString();
+          document.getElementById(`sizeValue-${this.id}`)!.textContent = this.patternSize.toString();
         }
         
         this.lastMouseX = this.mouseX;
@@ -193,8 +202,6 @@
     }
   }
 
-  // Initialize the kaleidoscope when the page loads
-  document.addEventListener('DOMContentLoaded', () => {
-    new Kaleidoscope();
-  });
+  // Initialize the kaleidoscope for this specific instance
+  new Kaleidoscope(id);
 </script> 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,5 +4,9 @@ import Kaleidoscope from '../components/Kaleidoscope.astro';
 ---
 
 <Layout title="Interactive Kaleidoscope">
-  <Kaleidoscope />
+  <div class="kaleidoscope-container">
+    <Kaleidoscope id="k1" />
+    <Kaleidoscope id="k2" />
+    <Kaleidoscope id="k3" />
+  </div>
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,1 +1,30 @@
 @import "tailwindcss";
+
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #111; /* Dark background */
+  color: #fff;
+  overflow-x: hidden; /* Prevent horizontal scroll */
+}
+
+.kaleidoscope-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100vh; /* Make container take full viewport height */
+}
+
+/* Ensure Astro's default #app or similar doesn't interfere with full height */
+astro-island, 
+#__astro-island {
+  height: 100%; 
+}
+
+/* If using a specific layout wrapper that needs full height */
+#main-content, /* Example ID, adjust if your Layout.astro uses a different wrapper */
+.layout-wrapper { /* Example class, adjust if your Layout.astro uses a different wrapper */
+  height: 100%;
+}


### PR DESCRIPTION
This change modifies the application to display three kaleidoscope instances on the main page instead of one.

Key modifications:
- Parameterized the `Kaleidoscope.astro` component to accept a unique `id` prop. This allows multiple instances to exist on the same page without ID conflicts for their canvas and control elements. The component's internal JavaScript class was updated to use this `id` for element selection.
- Updated `index.astro` to instantiate three `<Kaleidoscope />` components, each with a unique `id` ("k1", "k2", "k3").
- Adjusted the layout and styling:
    - Each kaleidoscope component instance now takes up one-third of the viewport height (`h-[33vh]`).
    - The `Kaleidoscope` class's `resize` method was updated to use parent element dimensions for the canvas, ensuring correct scaling within its container.
    - A `kaleidoscope-container` div was added to `index.astro` to manage the vertical stacking of the three kaleidoscopes using flexbox.
    - Global CSS was updated to support this layout and ensure full viewport height utilization.